### PR TITLE
first check if we even need to run DNS before calling DNS

### DIFF
--- a/lib/email_veracity/domain.rb
+++ b/lib/email_veracity/domain.rb
@@ -50,13 +50,13 @@ module EmailVeracity
       add_error(:blacklisted) if blacklisted? &&
         Config[:enforce_blacklist]
       unless Config[:skip_lookup]
-        add_error(:no_records) if servers.empty? &&
-          !Config.enforced_record?(:a) &&
-          !Config.enforced_record?(:mx)
-        add_error(:no_address_servers) if address_servers.empty? &&
-          Config.enforced_record?(:a)
-        add_error(:no_exchange_servers) if exchange_servers.empty? &&
-          Config.enforced_record?(:mx)
+        add_error(:no_records) if !Config.enforced_record?(:a) && 
+          !Config.enforced_record?(:mx) && 
+          servers.empty?
+        add_error(:no_address_servers) if Config.enforced_record?(:a) && 
+          address_servers.empty?
+        add_error(:no_exchange_servers) if Config.enforced_record?(:mx) &&
+          exchange_servers.empty?
       end
     end
 


### PR DESCRIPTION
The local config checks should be first in the conditional that way if the fail then the DNS checks are never even run... now the DNS is run first even if in some cases it does not need to be.
